### PR TITLE
Add support of the additional SMTP driver options

### DIFF
--- a/src/TransportManager.php
+++ b/src/TransportManager.php
@@ -23,6 +23,30 @@ class TransportManager
         $transport->setUsername($setting['username'] ?? $config->getEmail());
         $transport->setPassword($setting['pass']);
 
+        return self::configureSmtpDriver($transport, $provider);
+    }
+
+    /**
+     * Configure the additional SMTP driver options.
+     *
+     * @param  \Swift_SmtpTransport  $transport
+     * @param  array  $config
+     * @return \Swift_SmtpTransport
+     */
+    protected static function configureSmtpDriver($transport, $config)
+    {
+        if (isset($config['stream'])) {
+            $transport->setStreamOptions($config['stream']);
+        }
+
+        if (isset($config['source_ip'])) {
+            $transport->setSourceIp($config['source_ip']);
+        }
+
+        if (isset($config['local_domain'])) {
+            $transport->setLocalDomain($config['local_domain']);
+        }
+
         return $transport;
     }
 


### PR DESCRIPTION
to use some additional configuration like the stream that it's already supported in Laravel, add options on the **provider** in the **multimail config file**, e.g:
```
'provider' => [
    'default' =>
        [
            'driver'        => env('MAIL_DRIVER'),
            'host'          => env('MAIL_HOST'),
            'port'          => env('MAIL_PORT'),
            'encryption'    => env('MAIL_ENCRYPTION'),
            'stream'        => [
                'ssl' => [
                    'allow_self_signed' => true,
                    'verify_peer' => false,
                    'verify_peer_name' => false,
                ],
            ],
        ]
]
```